### PR TITLE
Fix ringtone set on Android 11 and newer

### DIFF
--- a/android/src/main/java/acr/rt/ringtone_set/RingtoneSetPlugin.java
+++ b/android/src/main/java/acr/rt/ringtone_set/RingtoneSetPlugin.java
@@ -213,7 +213,6 @@ public class RingtoneSetPlugin implements FlutterPlugin, MethodCallHandler {
             // Android 10 or newer
             if (android.os.Build.VERSION.SDK_INT > 28) {// file.exists
                 ContentValues values = new ContentValues();
-                values.put(MediaStore.MediaColumns.DATA, mFile.getAbsolutePath());
                 values.put(MediaStore.MediaColumns.TITLE, "Custom ringtone");
                 values.put(MediaStore.MediaColumns.MIME_TYPE, getMIMEType(mFile.getAbsolutePath(), downloadedMimeType));
                 values.put(MediaStore.MediaColumns.SIZE, mFile.length());


### PR DESCRIPTION
MediaStore.MediaColumns.DATA is read-only on Android 11 and newer.